### PR TITLE
Add settings to build for Mac

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -37,6 +37,22 @@
       ],
       "conditions": [
         ["OS=='linux'", {  
+        }],
+        ["OS=='mac'", {
+          "xcode_settings" : {
+            "MACOSX_DEPLOYMENT_TARGET": "10.7",
+            "GCC_ENABLE_CPP_EXCEPTIONS": "YES",
+            "OTHER_CFLAGS": [
+              "-mmacosx-version-min=10.7", "-std=c++11", "-stdlib=libc++", "-O3", "-D__STDC_CONSTANT_MACROS", "-D_FILE_OFFSET_BITS=64", 
+              "-D_LARGEFILE_SOURCE", "-fPIC", 
+              "`pkg-config --cflags libtorrent-rasterbar`"
+            ],
+            "OTHER_CPLUSPLUSFLAGS": [
+              "-mmacosx-version-min=10.7", "-std=c++11", "-stdlib=libc++", "-O3", "-D__STDC_CONSTANT_MACROS", "-D_FILE_OFFSET_BITS=64", 
+              "-D_LARGEFILE_SOURCE", "-fPIC", 
+              "`pkg-config --cflags libtorrent-rasterbar`"
+            ]
+          },
         }]
       ]
     }


### PR DESCRIPTION
I had a problem building node-libtorrent on Mac, kind of similar to [this one](https://github.com/fanatid/node-libtorrent/issues/4). Apparently, on Mac gyp ignores 'cflags_cc' and 'cflags_cc!' settings, so the build fails. 

This commit provides proper settings for Mac build. I also hit trouble with dynamic linking after the build, so added some extra settings to overcome it. 
